### PR TITLE
Replication PoC

### DIFF
--- a/example/pglogrepl_demo/main.go
+++ b/example/pglogrepl_demo/main.go
@@ -228,6 +228,7 @@ func (a *applyContext) queue(q string, args ...interface{}) {
 
 func (a *applyContext) begin() {
 	a.txnInProgress = true
+	a.timer.Stop()
 }
 
 func (a *applyContext) commit(commitLSN pglogrepl.LSN, commitTime time.Time) {

--- a/example/pglogrepl_demo/main.go
+++ b/example/pglogrepl_demo/main.go
@@ -12,6 +12,9 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/jackc/pgx/v5/pgtype"
+
+	"net/http"
+	_ "net/http/pprof"
 )
 
 func createReplicationOrigin(conn *pgx.Conn, name string) error {
@@ -37,6 +40,10 @@ func createReplicationOrigin(conn *pgx.Conn, name string) error {
 }
 
 func main() {
+	go func() {
+        log.Println(http.ListenAndServe("localhost:6060", nil))
+  }()
+
 	//	const outputPlugin = "test_decoding"
 	const outputPlugin = "pgoutput"
 	//const outputPlugin = "wal2json"


### PR DESCRIPTION
I quickly hacked into pglogrepl example program to replicate INSERT into the target.

It works. I see 50K inserts/sec with very minimal effort while using the [pgx Batch interface](https://pkg.go.dev/github.com/jackc/pgx/v5#Conn.SendBatch)(somewhat similar to the Pipeline mode we implemented in pgcopydb). I didn't spend time optimizing the insert using multi-value statements; I will reserve that for another day!

![image](https://github.com/user-attachments/assets/c94f67a0-dfbb-4afb-8a5a-21664bab2da2)

Logs:

```
2024/10/17 13:34:11 commit took 1.762367317s queue len 81141
2024/10/17 13:34:15 commit took 1.911329057s queue len 86941
2024/10/17 13:34:19 commit took 2.145220881s queue len 103621
```
